### PR TITLE
Rule 4200: switch to positive man-made allowlist (closes #4)

### DIFF
--- a/docs/MESSAGES.md
+++ b/docs/MESSAGES.md
@@ -19,13 +19,24 @@ References to "rules" below are defined in the javadoc in DateTagTest.java.
 |------|-------|
 | 4200 | `[ohm] Suspicious date - man-made object without start_date; unfixable, please review` |
 
-**Trigger:** Feature has a recognisable man-made tag (building, highway, amenity, etc.) but no `start_date`.  
+**Trigger:** Feature carries at least one tag from a curated **man-made allowlist** but has no `start_date`. The allowlist (see `DateTagTest.MANMADE_KEYS` and `MANMADE_DENYLIST`) covers buildings, highways, railways, amenities, leisure, barriers, addressed features, and other tags that mark a primitive as built / established with a discrete creation date.  
 **Fix:** None.  
 **Description:** _Please make every effort to attempt a reasonable range for the `start_date:edtf` tag and provide an explanation in the `start_date:source` tag._
 
-**Example:**  
-Trigger: `building=yes` with no `start_date` and no `natural=*` tag.  
+The trigger is a positive allowlist (since 2026-04). Earlier versions used a negative test ("any tag except `natural=*`") which over-fired badly on member ways of large boundary relations — see issue #4 (3344 warnings on the British Empire 1921-1922 relation, forum post 2026-04-21). A primitive with only `name=*`, `wikidata=*`, `boundary=*` (on a way), `addr:*`-free metadata, etc. no longer triggers; it must carry a positively man-made key.
+
+Notable allowlist entries:
+
+- **Always trigger (any value):** `building`, `building:part`, `highway`, `railway`, `aeroway`, `aerialway`, `bridge`, `tunnel`, `man_made`, `power`, `pipeline`, `amenity`, `shop`, `office`, `craft`, `tourism`, `historic`, `military`, `emergency`, `public_transport`, `telecom`, `leisure`, `barrier`, plus any `addr:*` key.
+- **Trigger unless value is in denylist:** `landuse` (skip `forest`/`meadow`/`grass`/`wood`/`scrub`/`heath`); `waterway` (skip `river`/`stream`/`brook`/`riverbank`/`tidal_channel`/`wadi`); `place` (skip `island`/`islet`/`archipelago`/`peninsula`/`cape`).
+- **Relation-only triggers:** `boundary=*` (the political entity has a date; member ways/nodes carrying `boundary=*` do **not** trigger because their date lives on the parent), and `type=route`.
+
+**Example (fires):**  
+Trigger: `building=yes` with no `start_date`.  
 Suggested manual fix: add `start_date:edtf=1920~/1940~` (or whatever bracket fits) plus `start_date:source=USGS topo 1925`.
+
+**Example (does not fire):**  
+A way tagged `boundary=administrative` with no other keys. The line segment's date is implicit from the parent relation; only the relation itself fires.
 
 ---
 

--- a/src/org/openstreetmap/josm/plugins/ohmtags/validation/DateTagTest.java
+++ b/src/org/openstreetmap/josm/plugins/ohmtags/validation/DateTagTest.java
@@ -6,9 +6,13 @@ import static org.openstreetmap.josm.tools.I18n.tr;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,6 +20,7 @@ import org.openstreetmap.josm.command.ChangePropertyCommand;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.command.SequenceCommand;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
+import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
@@ -256,16 +261,20 @@ public class DateTagTest extends Test {
     }
 
     private void checkPrimitive(OsmPrimitive p) {
-        // Rule: man-made features should have start_date.
-        // Only flag features that have some other identifying tag — don't
-        // complain about every untagged node (those are covered by other
-        // validators and would create too much noise).
+        // Rule 4200: man-made features should have start_date.
         //
         // Severity is WARNING, not ERROR, matching iD's validator. The OHM
         // wiki says "should" (not "must") for this tag; speculative start
         // dates are worse than missing ones, so this is a nudge to research
         // rather than a blocker to save.
-        if (p.get("start_date") == null && !hasNaturalTag(p) && p.hasKeys()) {
+        //
+        // The trigger is a positive allowlist (see isManMade): the primitive
+        // must carry at least one tag that explicitly marks it as built or
+        // established. The previous negative test ("any tag except natural")
+        // misfired badly on boundary relations whose member ways carry
+        // boundary=* but no independent date — see issue #4 (forum: 3344
+        // warnings on r/2828412 / British Empire 1921-1922).
+        if (p.get("start_date") == null && isManMade(p)) {
             errors.add(TestError.builder(this, Severity.WARNING, CODE_MISSING_START_DATE)
                 .message(tr("[ohm] Suspicious date - man-made object without start_date; unfixable, please review"),
                          tr("Please make every effort to attempt a reasonable range "
@@ -288,9 +297,71 @@ public class DateTagTest extends Test {
         checkAllEdtfKeys(p);
     }
 
-    /** True if the primitive has any {@code natural=*} tag. */
-    private static boolean hasNaturalTag(OsmPrimitive p) {
-        return p.get("natural") != null;
+    /**
+     * Keys whose presence (any value) marks the primitive as built /
+     * established and therefore in scope for the missing-{@code start_date}
+     * warning. Curated to match OSM/OHM tagging conventions for features
+     * that have a discrete creation date.
+     */
+    private static final Set<String> MANMADE_KEYS = new HashSet<>(Arrays.asList(
+        "building", "building:part",
+        "highway", "railway", "aeroway", "aerialway",
+        "bridge", "tunnel",
+        "man_made", "power", "pipeline",
+        "amenity", "shop", "office", "craft",
+        "tourism", "historic", "military", "emergency",
+        "public_transport", "telecom",
+        "leisure", "barrier"
+    ));
+
+    /**
+     * Keys that mark the primitive as built / established <em>unless</em>
+     * the value is in the per-key denylist. Used for tags that span both
+     * man-made and natural domains (e.g. {@code waterway=canal} vs.
+     * {@code waterway=river}).
+     */
+    private static final Map<String, Set<String>> MANMADE_DENYLIST = makeDenylist();
+
+    private static Map<String, Set<String>> makeDenylist() {
+        Map<String, Set<String>> m = new HashMap<>();
+        m.put("landuse", new HashSet<>(Arrays.asList(
+            "forest", "meadow", "grass", "wood", "scrub", "heath")));
+        m.put("waterway", new HashSet<>(Arrays.asList(
+            "river", "stream", "brook", "riverbank", "tidal_channel", "wadi")));
+        m.put("place", new HashSet<>(Arrays.asList(
+            "island", "islet", "archipelago", "peninsula", "cape")));
+        return m;
+    }
+
+    /**
+     * True if the primitive carries at least one tag from the man-made
+     * allowlist. See {@link #MANMADE_KEYS} and {@link #MANMADE_DENYLIST}.
+     *
+     * <p>Two relation-only signals on top of the per-key sets:
+     * <ul>
+     *   <li>{@code boundary=*} on a {@link Relation} (the political entity
+     *       has a discrete date; member ways/nodes are excluded so we don't
+     *       fire on every line segment of a boundary).</li>
+     *   <li>{@code type=route} on a {@link Relation} (bus, train, hiking,
+     *       ferry routes have an operating-start date).</li>
+     * </ul>
+     *
+     * <p>An {@code addr:*} key (any value) is a positive signal too — an
+     * address implies a built / locatable feature.
+     */
+    private static boolean isManMade(OsmPrimitive p) {
+        boolean isRelation = p instanceof Relation;
+        for (String key : p.keySet()) {
+            if (MANMADE_KEYS.contains(key)) return true;
+            if (key.startsWith("addr:")) return true;
+            Set<String> deny = MANMADE_DENYLIST.get(key);
+            if (deny != null && !deny.contains(p.get(key))) return true;
+            if (isRelation) {
+                if ("boundary".equals(key)) return true;
+                if ("type".equals(key) && "route".equals(p.get(key))) return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Closes #4 — replaces the negative `!hasNaturalTag` trigger on rule 4200 with a positive man-made allowlist.

## Background

> **danvk (forum post #11):** I downloaded [r/2828412](https://www.openhistoricalmap.org/relation/2828412) (British Empire 1921-1922) and ran the validator over it. I got 3344 "suspicious date - man-made object without start_date" warnings, which seems like a lot.
>
> **Jeff (post #12):** The British Empire issue sounds like a real bug.

The previous trigger fired on any primitive with at least one key that wasn't `natural=*`. A boundary relation's member ways all carry `boundary=administrative`, so 3344 line-segment ways fired the warning even though their date lives on the parent relation.

## What changed

`DateTagTest.checkPrimitive` now calls `isManMade(p)` instead of `!hasNaturalTag(p) && p.hasKeys()`. The helper checks the primitive's keys against three sets:

- **`MANMADE_KEYS`** — always-trigger keys (any value): `building`, `building:part`, `highway`, `railway`, `aeroway`, `aerialway`, `bridge`, `tunnel`, `man_made`, `power`, `pipeline`, `amenity`, `shop`, `office`, `craft`, `tourism`, `historic`, `military`, `emergency`, `public_transport`, `telecom`, `leisure`, `barrier`. Plus any `addr:*` key.
- **`MANMADE_DENYLIST`** — trigger unless value is in a per-key denylist:
  - `landuse` skips `forest` / `meadow` / `grass` / `wood` / `scrub` / `heath`
  - `waterway` skips `river` / `stream` / `brook` / `riverbank` / `tidal_channel` / `wadi`
  - `place` skips `island` / `islet` / `archipelago` / `peninsula` / `cape`
- **Relation-only signals**: `boundary=*` on a `Relation` triggers (the political entity has a date), but `boundary=*` on a `Way`/`Node` does not (those are member geometry); `type=route` also triggers on relations.

`hasNaturalTag` is removed (semantics fold into the negative side of the allowlist).

`docs/MESSAGES.md` rule 4200 section updated with the new trigger description and a "does not fire" example.

## Test plan

- [x] **Regression on `test/test_data.osm`:** 146 fewer rule-4200 emissions (1449 → 1303 warnings; 221 errors unchanged). Zero new emissions.
- [x] **Sample-check removed primitives:** `n/2125538393` (one of the removed ones) had only `entrance=yes` — correctly excluded as a building-component node rather than a standalone built feature.
- [x] **22 targeted classification spot-checks** all pass:

```
OK    way boundary=administrative                      expected=false actual=false
OK    way building=yes                                 expected=true  actual=true
OK    relation type=route                              expected=true  actual=true
OK    relation boundary=administrative                 expected=true  actual=true
OK    node addr:housenumber=42                         expected=true  actual=true
OK    way landuse=forest                               expected=false actual=false
OK    way landuse=residential                          expected=true  actual=true
OK    node place=island                                expected=false actual=false
OK    node place=town                                  expected=true  actual=true
OK    way natural=water                                expected=false actual=false
OK    way waterway=river                               expected=false actual=false
OK    way waterway=canal                               expected=true  actual=true
OK    way leisure=garden                               expected=true  actual=true
OK    way leisure=nature_reserve                       expected=true  actual=true
OK    way barrier=hedge                                expected=true  actual=true
OK    way highway=residential                          expected=true  actual=true
OK    relation type=multipolygon w/ building=yes       expected=true  actual=true
OK    relation type=multipolygon (no other tags)       expected=false actual=false
OK    untagged node                                    expected=false actual=false
OK    only name=Foo                                    expected=false actual=false
OK    only metadata (name, wikidata, ref)              expected=false actual=false
OK    boundary=admin AND building=yes way              expected=true  actual=true
```

- [ ] **British Empire fixture:** still pending — OHM API is gated by Cloudflare's JS challenge, so r/2828412 needs to be downloaded interactively via JOSM and saved to `test/r2828412_british_empire_1921.osm`. Will follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
