### PR TITLE
Narrow rules 4300 and 4301 (closes #12, #13)

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -18,6 +18,26 @@ port author's responsibility, not the original author's.
 - Originating commit: https://github.com/OpenHistoricalMap/iD/commit/4d5cb19
 - Original license: ISC (see `LICENSES/iD-ISC.txt`)
 
+## Bundled third-party library: edtf-java
+
+The plugin's distributed JAR (`dist/ohm-tags.jar`) shades in the
+[`edtf-java`](https://github.com/OpenHistoricalMap/edtf-java) library
+(`io.github.openhistoricalmap:edtf:0.2.0`), used as the source of
+truth for EDTF parsing, validation, and bound extraction. The
+library's BSD 2-Clause license requires that the copyright notice
+accompany binary redistributions; the upstream `META-INF/LICENSE`,
+`META-INF/NOTICE`, and `META-INF/LICENSE-edtf.js.txt` files are
+preserved inside the shaded JAR.
+
+`edtf-java` itself derives from
+[`edtf.js`](https://github.com/inukshuk/edtf.js) (also BSD 2-Clause).
+
+- Library source: https://github.com/OpenHistoricalMap/edtf-java
+- Maven Central: `io.github.openhistoricalmap:edtf:0.2.0`
+- Library license: BSD 2-Clause (see `LICENSES/edtf-java-BSD-2-Clause.txt`)
+- Upstream JS library license: BSD 2-Clause (preserved in the shaded
+  JAR's `META-INF/LICENSE-edtf.js.txt`)
+
 ## AI-assisted development
 
 This project was developed with substantial assistance from Claude

--- a/LICENSES/edtf-java-BSD-2-Clause.txt
+++ b/LICENSES/edtf-java-BSD-2-Clause.txt
@@ -1,0 +1,13 @@
+Copyright (c) 2026 OpenHistoricalMap.org
+
+This project includes code based on or derived from edtf.js.
+
+edtf.js
+Copyright (c) 2016–2025 EDTF.js Authors and Contributors
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ independently updatable.
 
 The plugin also depends on the
 [`edtf-java`](https://github.com/OpenHistoricalMap/edtf-java) library
-(`io.github.openhistoricalmap:edtf:0.2.0`) for canonical EDTF parsing.
-The library is fetched automatically from Maven Central by the
-`fetch-dependencies` Ant target and shaded into the plugin JAR at
-build time, so JOSM users don't need to install anything extra.
+(`io.github.openhistoricalmap:edtf:0.2.0`, BSD 2-Clause) for canonical
+EDTF parsing. The library is fetched automatically from Maven Central
+by the `fetch-dependencies` Ant target and shaded into the plugin JAR
+at build time, so JOSM users don't need to install anything extra.
+The shaded JAR preserves the upstream BSD notice in its `META-INF/`;
+see `ATTRIBUTION.md` and `LICENSES/edtf-java-BSD-2-Clause.txt` for the
+full attribution.
 
 ```bash
 git clone https://github.com/OpenHistoricalMap/ohm-josm-tag-validator.git

--- a/docs/MESSAGES.md
+++ b/docs/MESSAGES.md
@@ -387,19 +387,25 @@ After autofix: `start_date=1582-10-14` (Gregorian equivalent), `start_date:note=
 | 4300 | `[ohm] Missing tag - name=*; unfixable, please review` |
 | 4301 | `[ohm] Name warning - parentheses in name; unfixable, please review` |
 
-**4300 trigger:** Feature has language-variant name keys (e.g. `name:en`) but no plain `name` key.  
+**4300 trigger:** Feature has language-variant name keys (e.g. `name:en`) but no plain `name` key. **Skipped on `type=route` relations** — routes are conventionally identified by `ref` (route number / designation), so name-family-only routes are legitimate.  
 **4300 description:** _Feature has name-family keys ({key}, etc.) but no plain 'name' key. Please add a canonical name._
 
-**4301 trigger:** A `name` key contains parentheses, typically encoding dates — discouraged in OHM names.  
-**4301 description:** _{key}={value}: '(dates)' are discouraged in names; please review and remove any dates in name keys._
+**4301 trigger:** A `name` key contains parentheses **and** the parenthesised content includes a year-like number (3-4 consecutive digits). The rule is narrowed to date-bearing parens — `(Springfield)` or `(north section)` no longer fire; `(1880-1922)` and `(c. 1900)` do.  
+**4301 description:** _{key}={value}: dates in parentheses are discouraged in names; move the date to start_date / end_date instead._
 
-**4300 example:**  
-Trigger: feature with `name:en=Empire State Building`, `name:fr=Empire State Building`, no plain `name`.  
+**4300 example (fires):**  
+Trigger: way with `name:en=Empire State Building`, `name:fr=Empire State Building`, no plain `name`.  
 Suggested manual fix: add `name=Empire State Building` (or whichever language is canonical for the location).
 
-**4301 example:**  
+**4300 example (does not fire):**  
+A relation with `type=route`, `route=bus`, `name:en=Pacific Coast Highway`, `ref=1`. Routes can rely on `ref` for canonical identity.
+
+**4301 example (fires):**  
 Trigger: `name=Old Town Hall (1880-1922)`  
 Suggested manual fix: change to `name=Old Town Hall`; encode dates in `start_date`/`end_date` instead.
+
+**4301 example (does not fire):**  
+`name=City Park (Springfield)` — parenthesised disambiguator with no year-like content; left alone.
 
 ---
 

--- a/src/org/openstreetmap/josm/plugins/ohmtags/validation/TagConsistencyTest.java
+++ b/src/org/openstreetmap/josm/plugins/ohmtags/validation/TagConsistencyTest.java
@@ -13,6 +13,7 @@ import org.openstreetmap.josm.command.ChangePropertyCommand;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.command.SequenceCommand;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
+import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
@@ -190,11 +191,11 @@ public class TagConsistencyTest extends Test {
             if (NAME_FAMILY_KEY.matcher(key).matches()) {
                 hasAnyNameFamily = true;
                 String value = p.get(key);
-                if (value != null && (value.contains("(") || value.contains(")"))) {
+                if (value != null && containsDateInParens(value)) {
                     errors.add(TestError.builder(this, Severity.WARNING, CODE_NAME_HAS_PARENS)
                         .message(tr("[ohm] Name warning - parentheses in name; unfixable, please review"),
-                                 tr("{0}={1}: ''(dates)'' are discouraged in names; "
-                                    + "please review and remove any dates in name keys.",
+                                 tr("{0}={1}: dates in parentheses are discouraged in names; "
+                                    + "move the date to start_date / end_date instead.",
                                     key, value))
                         .primitives(p)
                         .build());
@@ -236,8 +237,11 @@ public class TagConsistencyTest extends Test {
 
         if (!hasAnyNameFamily) return; // No name-related checks apply.
 
-        // Rule: any name-family keys but no plain name.
-        if (!hasPlainName) {
+        // Rule: any name-family keys but no plain name. Skip on type=route
+        // relations — routes are conventionally identified by ref (route
+        // number / designation) rather than a country-neutral name; a route
+        // legitimately may have only name:lang=* variants.
+        if (!hasPlainName && !isRouteRelation(p)) {
             errors.add(TestError.builder(this, Severity.WARNING, CODE_MISSING_PLAIN_NAME)
                 .message(tr("[ohm] Missing tag - name=*; unfixable, please review"),
                          tr("Feature has name-family keys ({0}, etc.) but no plain "
@@ -286,6 +290,39 @@ public class TagConsistencyTest extends Test {
             if (NAME_FAMILY_KEY.matcher(key).matches()) return key;
         }
         return "name:*"; // Shouldn't be reached — caller checked hasAnyNameFamily.
+    }
+
+    /** Matches a parenthesised group capturing its contents. */
+    private static final Pattern PARENS_GROUP =
+        Pattern.compile("\\(([^)]*)\\)");
+
+    /**
+     * Year-like pattern: 3 or 4 consecutive digits as a word. Catches
+     * {@code 1880}, {@code 500} (BCE), {@code 2024-03} (the 2024 part),
+     * range halves like {@code 1880-1922}.
+     */
+    private static final Pattern YEAR_LIKE =
+        Pattern.compile("\\b\\d{3,4}\\b");
+
+    /**
+     * True if {@code value} contains a parenthesised group whose contents
+     * include a year-like number sequence. Used to narrow rule 4301 to
+     * names that actually encode dates in parens, not non-date
+     * disambiguation like {@code (Springfield)} or {@code (north section)}.
+     */
+    private static boolean containsDateInParens(String value) {
+        Matcher m = PARENS_GROUP.matcher(value);
+        while (m.find()) {
+            if (YEAR_LIKE.matcher(m.group(1)).find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** True if the primitive is a {@link Relation} with {@code type=route}. */
+    private static boolean isRouteRelation(OsmPrimitive p) {
+        return p instanceof Relation && "route".equals(p.get("type"));
     }
 
     /**


### PR DESCRIPTION
Two small targeted refinements to suppress false positives in the name-family checks.

## #12 — Rule 4300 (missing plain `name=`) skips `type=route` relations

Routes (bus, train, hiking, ferry) conventionally identify with `ref`, not `name`. Many routes legitimately carry only `name:lang=*` variants without a plain `name`; the rule was firing on those. New early-return guard:

```java
if (!hasPlainName && !isRouteRelation(p)) { ... emit 4300 ... }
```

## #13 — Rule 4301 (parentheses in `name`) requires a date-like token

Previously any parenthesis fired the rule, catching legitimate non-date disambiguators like `name=City Park (Springfield)` and `name=Foo (S.T.C.P.)`. Now the parenthesised content must contain a year-like number (3-4 consecutive digits, matched by `\b\d{3,4}\b`).

| Name | Old behaviour | New behaviour |
|---|---|---|
| `Old Mill (1880-1922)` | fires | fires |
| `Smith Memorial (1900)` | fires | fires |
| `Building (500 BCE)` | fires | fires |
| `City Park (Springfield)` | **fires (false +)** | no fire |
| `Foo (vielleicht Pferde Training)` | **fires (false +)** | no fire |
| `Foo (S.T.C.P.)` | **fires (false +)** | no fire |

Also slightly retones the description: `'(dates)' are discouraged in names` → `dates in parentheses are discouraged in names; move the date to start_date / end_date instead`.

## Implementation

Two new private helpers in `TagConsistencyTest`:

- `containsDateInParens(String)` — scans `(...)` groups for `\b\d{3,4}\b`
- `isRouteRelation(OsmPrimitive)` — true when `p instanceof Relation && "route".equals(p.get("type"))`

## Test plan

- [x] `ant test` on `test_data.osm`: 4301 emissions 2 → 0 (both prior emissions were exactly the targeted false positives — the German `(vielleicht Pferde Training)` and the abbreviation `(S.T.C.P.)`). 4300 emissions 2 → 2 (no `type=route` relations in fixture; both survivors are legitimate `old_name`/`alt_name`-only ways).
- [x] **20 targeted unit checks pass** — covers date-bearing positives, non-date negatives, multi-paren strings, and `isRouteRelation` classifier on Way / Node / Relation primitives.

```
--- containsDateInParens ---
OK    Old Mill (1880-1922)               -> true
OK    Smith Memorial (1900)              -> true
OK    Building (500 BCE)                 -> true
OK    Foo (c. 1880)                      -> true
OK    Bar (1880-03)                      -> true
OK    Two (parens) (1900)                -> true
OK    City Park (Springfield)            -> false
OK    Smith House (residence)            -> false
OK    Bridge Street (north section)      -> false
OK    Foo (S.T.C.P.)                     -> false
OK    Foo (vielleicht Pferde Training)   -> false
OK    Plain Name                         -> false
OK    Foo (12)                           -> false  (2 digits doesn't qualify)
OK    Bar (#42)                          -> false

--- isRouteRelation ---
OK    relation type=route bus            -> true
OK    relation type=route hiking         -> true
OK    relation type=multipolygon         -> false
OK    relation no type                   -> false
OK    way with type=route                -> false
OK    node with type=route               -> false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
